### PR TITLE
feat: storytelling metadata + shared trips (schema, rules, invitations, UI, tests)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -16,6 +16,19 @@ service cloud.firestore {
       allow read, write: if isOwner(userId);
     }
 
+    // 1.a Viajes compartidos: permitir lectura a usuarios listados en sharedWith (owner o invitados aceptados)
+    match /usuarios/{userId}/viajes/{viajeId} {
+      allow read: if isOwner(userId) || (isAuthenticated() && request.auth.uid in resource.data.sharedWith);
+      allow write: if isOwner(userId);
+    }
+
+    // Subcolecciones dentro de un viaje (paradas, fotos, etc.) — lectura para owner o usuarios en sharedWith
+    match /usuarios/{userId}/viajes/{viajeId}/{subDocument=**} {
+      allow read: if isOwner(userId) || (isAuthenticated() && request.auth.uid in get(/databases/$(database)/documents/usuarios/$(userId)/viajes/$(viajeId)).data.sharedWith);
+      allow write: if isOwner(userId);
+    }
+
+    // 1.b Resto de subcolecciones del usuario (solo propietario)
     match /usuarios/{userId}/{document=**} {
       allow read, write: if isOwner(userId);
     }

--- a/src/components/Modals/EdicionModal.test.jsx
+++ b/src/components/Modals/EdicionModal.test.jsx
@@ -8,6 +8,10 @@ vi.mock('../../hooks/useWindowSize', () => ({ useWindowSize: () => ({ isMobile: 
 vi.mock('../../hooks/useGaleriaViaje', () => ({ useGaleriaViaje: () => ({ fotos: [], uploading: false, limpiar: vi.fn(), cambiarPortada: vi.fn(), eliminar: vi.fn(), actualizarCaption: vi.fn() }) }));
 // Mock del módulo firebase para evitar referencias a `window` durante tests
 vi.mock('../../firebase', () => ({ db: {}, storage: {} }));
+// Mock simple para UploadContext (evita necesidad de provider en tests)
+vi.mock('../../context/UploadContext', () => ({ useUpload: () => ({ iniciarSubida: vi.fn(), getEstadoViaje: () => ({}) }) }));
+// Mock simple para UploadContext (evita necesidad de provider en tests)
+vi.mock('../../context/UploadContext', () => ({ useUpload: () => ({ iniciarSubida: vi.fn(), getEstadoViaje: () => ({}) }) }));
 
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';

--- a/src/components/Modals/__tests__/EdicionModal.test.jsx
+++ b/src/components/Modals/__tests__/EdicionModal.test.jsx
@@ -1,10 +1,28 @@
+// @vitest-environment jsdom
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as authModule from '../../../context/AuthContext';
 import * as windowSizeModule from '../../../hooks/useWindowSize';
 import * as galeriaHook from '../../../hooks/useGaleriaViaje';
 import { ToastProvider } from '../../../context/ToastContext';
+
+// Mocks para UploadContext y Firestore used in autocomplete
+vi.mock('../../../context/UploadContext', () => ({ useUpload: () => ({ iniciarSubida: vi.fn(), getEstadoViaje: () => ({}) }) }));
+vi.mock('firebase/firestore', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    // asegurar que getFirestore existe para evitar errores en otros módulos
+    getFirestore: actual.getFirestore || (app => ({})),
+    // solo mockear getDocs para los tests de autocomplete; preservar el resto
+    getDocs: vi.fn(async () => ({ docs: [] }))
+  };
+});
+
+// Evitar que se ejecute la inicialización real de Firebase en tests
+vi.mock('../../../firebase', () => ({ db: {}, storage: {} }));
+
 
 // Mocks de componentes hijos para aislar el test
 vi.mock('../../Shared/GalleryUploader', () => ({
@@ -68,5 +86,59 @@ describe('EdicionModal (comportamiento básico)', () => {
 
     // Debería mostrarse el badge "Portada" proveniente de la galería del servidor
     expect(screen.getByText('Portada')).toBeInTheDocument();
+  });
+
+  test('agrega companion por freeform y lo muestra en la lista', async () => {
+    vi.spyOn(galeriaHook, 'useGaleriaViaje').mockReturnValue({ fotos: [], uploading: false, limpiar: vi.fn() });
+    const viaje = { id: 'new', nombreEspanol: 'Chile', titulo: '', code: 'CL', flag: null };
+
+    render(
+      <ToastProvider>
+        <EdicionModal viaje={viaje} onClose={vi.fn()} onSave={vi.fn()} esBorrador={true} ciudadInicial={null} />
+      </ToastProvider>
+    );
+
+    const input = screen.getByPlaceholderText('Nombre o email');
+    await userEvent.type(input, 'Ana');
+    await userEvent.click(screen.getByRole('button', { name: /Agregar/i }));
+
+    expect(screen.getByText('Ana')).toBeInTheDocument();
+  });
+
+  test('autocomplete encuentra usuario y al agregar crea invitación si viaje guardado', async () => {
+    // Mock de useGaleriaViaje
+    vi.spyOn(galeriaHook, 'useGaleriaViaje').mockReturnValue({ fotos: [], uploading: false, limpiar: vi.fn() });
+
+    // Mock del módulo de firestore getDocs para devolver un usuario simulado
+    const mockDocs = [{ id: 'u2', data: () => ({ displayName: 'Test User', email: 'test@example.com' }) }];
+    const firestore = await import('firebase/firestore');
+    firestore.getDocs.mockResolvedValue({ docs: mockDocs });
+
+    // Espiar createInvitation para verificar llamado
+    const invitations = await import('../../../services/invitationsService');
+    vi.spyOn(invitations, 'createInvitation').mockResolvedValue('inv-1');
+
+    const viaje = { id: 'v1', nombreEspanol: 'Perú', titulo: 'Viaje a Perú', code: 'PE', flag: null };
+
+    render(
+      <ToastProvider>
+        <EdicionModal viaje={viaje} onClose={vi.fn()} onSave={vi.fn()} esBorrador={false} ciudadInicial={null} />
+      </ToastProvider>
+    );
+
+    const input = screen.getByPlaceholderText('Nombre o email');
+    await userEvent.type(input, 'Test');
+
+    // esperar a que aparezcan resultados (mocked)
+    await waitFor(() => expect(screen.getByText('Test User')).toBeInTheDocument());
+
+    // Click en agregar desde resultados
+    await userEvent.click(screen.getAllByText('Agregar')[0]);
+
+    // Debe mostrarse el companion en la lista
+    expect(screen.getByText('Test User')).toBeInTheDocument();
+
+    // Debe haberse llamado createInvitation (viaje guardado)
+    expect(invitations.createInvitation).toHaveBeenCalled();
   });
 });

--- a/src/components/Shared/CityManager.jsx
+++ b/src/components/Shared/CityManager.jsx
@@ -37,7 +37,9 @@ const CityManager = ({ paradas, setParadas }) => {
       fechaSalida: '', 
       fecha: new Date().toISOString().split('T')[0], 
       paisCodigo: countryCode, 
-      flag: getFlagUrl(countryCode) // Guardar URL SVG
+      flag: getFlagUrl(countryCode), // Guardar URL SVG
+      transporte: null,
+      notaCorta: ''
     };
     setParadas([...paradas, nuevaParada]);
     setBusqueda('');
@@ -124,6 +126,20 @@ const CityManager = ({ paradas, setParadas }) => {
                     <input type="date" value={p.fechaSalida} onChange={e => actualizarDato(index, 'fechaSalida', e.target.value)} style={styles.dateInput} />
                 </div>
             </div>
+
+            <div style={styles.transportRow}>
+                <div style={{display:'flex', gap:8, alignItems:'center'}}>
+                    <button type="button" onClick={() => actualizarDato(index, 'transporte', 'avion')} style={styles.transportBtn(p.transporte === 'avion')}>✈️ Avión</button>
+                    <button type="button" onClick={() => actualizarDato(index, 'transporte', 'tren')} style={styles.transportBtn(p.transporte === 'tren')}>🚆 Tren</button>
+                    <button type="button" onClick={() => actualizarDato(index, 'transporte', 'auto')} style={styles.transportBtn(p.transporte === 'auto')}>🚗 Auto</button>
+                    <button type="button" onClick={() => actualizarDato(index, 'transporte', 'bus')} style={styles.transportBtn(p.transporte === 'bus')}>🚌 Bus</button>
+                    <button type="button" onClick={() => actualizarDato(index, 'transporte', 'otro')} style={styles.transportBtn(p.transporte === 'otro')}>🔁 Otro</button>
+                </div>
+                <div style={{flex:1, marginLeft:12}}>
+                    <label style={styles.label}>Nota</label>
+                    <input type="text" value={p.notaCorta || ''} onChange={e => actualizarDato(index, 'notaCorta', e.target.value)} placeholder="Nota corta (ej: 'Perdí el tren')" style={styles.dateInput} />
+                </div>
+            </div>
           </div>
         ))}
       </div>
@@ -147,6 +163,8 @@ const styles = {
   actionBtn: { background: '#f1f5f9', border: 'none', padding: '6px', borderRadius: '6px', cursor: 'pointer', color: '#64748b', display:'flex', alignItems:'center', justifyContent:'center' },
   datesRow: { display: 'flex', gap: '15px' },
   dateGroup: { flex: 1, display: 'flex', flexDirection: 'column', gap: '4px' },
+  transportRow: { display: 'flex', gap: '12px', alignItems: 'center', marginTop: 10 },
+  transportBtn: (active) => ({ padding: '6px 10px', borderRadius: 8, border: active ? '1px solid #3b82f6' : '1px solid #e2e8f0', background: active ? '#eff6ff' : '#fff', cursor: 'pointer' }),
   label: { fontSize: '0.7rem', textTransform:'uppercase', color:'#94a3b8', fontWeight:'700' },
   dateInput: { border: '1px solid #e2e8f0', borderRadius: '8px', padding: '8px', fontSize: '0.85rem', color: COLORS.charcoalBlue, outline:'none', background:'#f8fafc' }
 };

--- a/src/components/VisorViaje/VisorViaje.jsx
+++ b/src/components/VisorViaje/VisorViaje.jsx
@@ -262,6 +262,31 @@ const VisorViaje = ({
                 : ''}
             </div>
 
+            {/* Trip summary (presupuesto, vibe, companions, highlights) */}
+            <div style={{ marginTop: 12 }}>
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+                {data.presupuesto && (
+                  <span style={{ padding: '6px 10px', borderRadius: 16, background: '#f8fafc', border: '1px solid #e2e8f0', fontSize: '0.85rem' }}>{data.presupuesto}</span>
+                )}
+                {(data.vibe || []).map((v, i) => (
+                  <span key={i} style={{ padding: '6px 10px', borderRadius: 16, background: '#fff7ed', border: '1px solid #fce6c6', fontSize: '0.8rem' }}>{v}</span>
+                ))}
+
+                <div style={{ display: 'flex', gap: 6, marginLeft: 'auto', alignItems: 'center' }}>
+                  {(data.companions || []).slice(0,4).map((c, idx) => (
+                    <div key={idx} title={c.name} style={{ width: 28, height: 28, borderRadius: 14, background: '#f8fafc', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '0.75rem', border: '1px solid #e2e8f0' }}>{(c.name || 'U').split(' ').map(s=>s[0]).slice(0,2).join('')}</div>
+                  ))}
+                  {(data.companions || []).length > 4 && <span style={{ color: '#64748b', fontSize: '0.85rem' }}>+{(data.companions || []).length - 4}</span>}
+                </div>
+              </div>
+
+              <div style={{ display: 'flex', gap: 12, marginTop: 10, flexWrap: 'wrap' }}>
+                {data.highlights?.topFood && <div style={{ background: '#ffffff', border: '1px solid #e6edf3', padding: '8px 12px', borderRadius: 10 }}>🍽️ {data.highlights.topFood}</div>}
+                {data.highlights?.topView && <div style={{ background: '#ffffff', border: '1px solid #e6edf3', padding: '8px 12px', borderRadius: 10 }}>👀 {data.highlights.topView}</div>}
+                {data.highlights?.topTip && <div style={{ background: '#ffffff', border: '1px solid #e6edf3', padding: '8px 12px', borderRadius: 10 }}>💡 {data.highlights.topTip}</div>}
+              </div>
+            </div>
+
             {!modoEdicion && fotoMostrada && data.fotoCredito && (
               <a
                 href={`${data.fotoCredito.link}?utm_source=keeptrip&utm_medium=referral`}

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -40,7 +40,7 @@ const storage = getStorage(app);
 export const googleProvider = new GoogleAuthProvider();
 
 // Detectar localhost/127.0.0.1 y conectar a Emuladores
-if ((window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1") && useEmulators) {
+if (typeof window !== 'undefined' && (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1") && useEmulators) {
   const EMULATOR_HOST = 'localhost';
   console.log(`🔧 Conectando a Firebase Emulators (${EMULATOR_HOST})...`);
   // Nota: disableWarnings ayuda a limpiar la consola en desarrollo

--- a/src/schemas/viajeSchema.js
+++ b/src/schemas/viajeSchema.js
@@ -112,6 +112,10 @@ export const ParadaSchema = z.object({
     max: z.number().optional()
   }).optional().nullable(),
   tipo: z.enum(['place', 'city', 'landmark', 'other']).default('place'),
+  // Nuevo: transporte entre puntos (ayuda logística / storytelling)
+  transporte: z.enum(['avion','tren','auto','bus','otro']).optional(),
+  // Nota corta vinculada a la parada (micro‑momento)
+  notaCorta: z.string().max(200).optional().nullable(),
   viajeId: z.string().optional() // Referencia al viaje padre
 });
 
@@ -153,6 +157,22 @@ export const ViajeSchemaBase = z.object({
   // Nuevos campos para galería (preparados para futuro)
   fotoPortada: URLImagenSchema, // URL de la foto principal
   totalFotos: z.number().int().min(0).max(30).default(1), // Límite de 30 fotos
+  // Storytelling metadata (nuevo)
+  presupuesto: z.string().optional().nullable(), // p.ej. 'Mochilero', 'Lujo'
+  vibe: z.array(z.string()).default([]), // tags de identidad (Relax, Aventura...)
+  highlights: z.object({
+    topFood: z.string().max(120).optional().nullable(),
+    topView: z.string().max(120).optional().nullable(),
+    topTip: z.string().max(240).optional().nullable()
+  }).optional().nullable(),
+  // Companions + sharing
+  companions: z.array(z.object({
+    name: z.string(),
+    email: z.string().optional().nullable(),
+    userId: z.string().optional().nullable(),
+    status: z.enum(['pending','accepted']).default('pending')
+  })).default([]),
+  sharedWith: z.array(z.string()).default([]), // uids que aceptaron ver el viaje
   // Metadata de ubicación
   banderas: z.array(z.string().url()).default([]),
   ciudades: z.string().optional().nullable(), // CSV de ciudades

--- a/src/schemas/viajeSchema.test.js
+++ b/src/schemas/viajeSchema.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { ViajeSchemaBase, ParadaSchema, validarParada, validarViaje } from './viajeSchema';
+
+describe('viajeSchema - nuevos campos de storytelling y sharing', () => {
+  it('ViajeSchemaBase acepta campos: presupuesto, vibe, highlights, companions, sharedWith', () => {
+    const sample = {
+      code: 'AR',
+      nombreEspanol: 'Argentina',
+      titulo: 'Roadtrip por la Patagonia',
+      fechaInicio: '2025-01-10',
+      fechaFin: '2025-01-20',
+      presupuesto: 'Mochilero',
+      vibe: ['Aventura', 'Naturaleza'],
+      highlights: { topFood: 'Asado', topView: 'Fitz Roy', topTip: 'Ir temprano' },
+      companions: [{ name: 'María', email: 'maria@example.com', status: 'pending' }],
+      sharedWith: ['uid-123'],
+      fotoCredito: null
+    };
+
+    const parsed = ViajeSchemaBase.parse(sample);
+    expect(parsed.presupuesto).toBe('Mochilero');
+    expect(parsed.vibe).toEqual(['Aventura', 'Naturaleza']);
+    expect(parsed.highlights.topView).toBe('Fitz Roy');
+    expect(Array.isArray(parsed.companions)).toBe(true);
+    expect(parsed.sharedWith).toEqual(['uid-123']);
+  });
+
+  it('ParadaSchema acepta transporte y notaCorta', () => {
+    const p = {
+      nombre: 'El Calafate',
+      coordenadas: [-72.27, -50.33],
+      fecha: '2025-01-12',
+      transporte: 'auto',
+      notaCorta: 'Noche increíble con estrellas'
+    };
+
+    const parsed = ParadaSchema.parse(p);
+    expect(parsed.transporte).toBe('auto');
+    expect(parsed.notaCorta).toBe('Noche increíble con estrellas');
+  });
+
+  it('validarParada reconoce parada válida con transporte', () => {
+    const resultado = validarParada({
+      nombre: 'Test',
+      coordenadas: [0, 0],
+      transporte: 'bus'
+    });
+    expect(resultado.esValido).toBe(true);
+  });
+
+  it('validarViaje acepta objeto minimal que incluye nuevos campos (no estricta)', () => {
+    const datos = {
+      code: 'AR',
+      nombreEspanol: 'Argentina',
+      titulo: 'Corto',
+      fechaInicio: '2025-02-01',
+      fechaFin: '2025-02-05',
+      vibe: ['Relax']
+    };
+
+    const resultado = validarViaje(datos, false);
+    expect(resultado.esValido).toBe(true);
+  });
+});

--- a/src/services/invitationsService.js
+++ b/src/services/invitationsService.js
@@ -1,0 +1,56 @@
+import {
+  collection,
+  addDoc,
+  doc,
+  getDocs,
+  query,
+  where,
+  updateDoc,
+  arrayUnion
+} from 'firebase/firestore';
+
+/**
+ * Servicio mínimo para manejar invitations (creación y aceptación).
+ * - createInvitation: crea un documento en `invitations/`
+ * - acceptInvitation: marca accepted y agrega uid a `usuarios/{inviterId}/viajes/{viajeId}.sharedWith`
+ * - getInvitationsForEmail: consulta invitaciones por email
+ */
+
+export const createInvitation = async ({ db, inviterId, inviteeEmail = null, inviteeUid = null, viajeId }) => {
+  const invitationsRef = collection(db, 'invitations');
+  const payload = {
+    inviterId: inviterId || null,
+    inviteeEmail: inviteeEmail || null,
+    inviteeUid: inviteeUid || null,
+    viajeId: viajeId || null,
+    status: 'pending',
+    createdAt: new Date()
+  };
+  const docRef = await addDoc(invitationsRef, payload);
+  return docRef.id;
+};
+
+export const acceptInvitation = async ({ db, invitationId, acceptorUid, inviterId, viajeId }) => {
+  try {
+    // Marcar invitación como accepted
+    const invitationRef = doc(db, 'invitations', invitationId);
+    await updateDoc(invitationRef, { status: 'accepted', acceptedAt: new Date(), acceptedBy: acceptorUid });
+
+    // Agregar al sharedWith del viaje (siempre que conozcamos inviterId y viajeId)
+    if (inviterId && viajeId) {
+      const viajeRef = doc(db, 'usuarios', inviterId, 'viajes', viajeId);
+      await updateDoc(viajeRef, { sharedWith: arrayUnion(acceptorUid) });
+    }
+
+    return true;
+  } catch (err) {
+    console.error('acceptInvitation error', err);
+    return false;
+  }
+};
+
+export const getInvitationsForEmail = async ({ db, email }) => {
+  const q = query(collection(db, 'invitations'), where('inviteeEmail', '==', email));
+  const snap = await getDocs(q);
+  return snap.docs.map(d => ({ id: d.id, ...d.data() }));
+};

--- a/src/utils/viajeUtils.js
+++ b/src/utils/viajeUtils.js
@@ -35,6 +35,12 @@ export const generarTituloInteligente = (nombreBase, paradas = []) => {
   const ciudadesUnicas = [...new Set(paradas.map((p) => p.nombre).filter(Boolean))];
   const paisesUnicos = [...new Set(paradas.map((p) => p.paisCodigo).filter(Boolean))];
 
+  // Si hay exactamente 2 países distintos, priorizar ese título (ej: España y Francia)
+  if (paisesUnicos.length === 2) {
+    const nombresPaises = paisesUnicos.map((c) => getCountryName(c)).filter(Boolean);
+    if (nombresPaises.length === 2) return `Aventura entre ${nombresPaises[0]} y ${nombresPaises[1]}`;
+  }
+
   // Priorizar títulos por ciudad cuando quedan claros y cortos
   if (ciudadesUnicas.length === 1) return `Escapada a ${ciudadesUnicas[0]}`;
   if (ciudadesUnicas.length === 2) return `${ciudadesUnicas[0]} y ${ciudadesUnicas[1]}`;
@@ -46,11 +52,6 @@ export const generarTituloInteligente = (nombreBase, paradas = []) => {
   if (paisesUnicos.length === 1) {
     const nombrePais = nombresPaises[0] || nombreBase;
     return `Ruta por ${nombrePais}`; // claro y directo
-  }
-
-  if (paisesUnicos.length === 2) {
-    // Evocar movimiento/transición entre dos países
-    return `Aventura entre ${nombresPaises[0]} y ${nombresPaises[1]}`;
   }
 
   if (paisesUnicos.length === 3) {
@@ -84,7 +85,10 @@ export const construirParadaPayload = (parada, fechaUso, climaInfo) => ({
   fechaSalida: parada.fechaSalida || '',
   paisCodigo: parada.paisCodigo || '',
   clima: climaInfo,
-  tipo: 'place'
+  tipo: 'place',
+  // Nuevos campos para storytelling/logística
+  transporte: parada.transporte || null,
+  notaCorta: parada.notaCorta || null
 });
 
 export const construirViajePayload = ({
@@ -107,6 +111,11 @@ export const construirViajePayload = ({
     rating: 5,
     foto: foto || FOTO_DEFAULT_URL,
     fotoCredito: fotoCredito || null,
+    // Storytelling fields (passthrough desde formData)
+    presupuesto: datosViaje.presupuesto || null,
+    vibe: datosViaje.vibe || [],
+    highlights: datosViaje.highlights || null,
+    companions: datosViaje.companions || [],
     banderas,
     ciudades
   };

--- a/src/utils/viajeUtils.test.js
+++ b/src/utils/viajeUtils.test.js
@@ -80,9 +80,9 @@ describe('viajeUtils', () => {
     expect(ciudades).toBe('Lima, Cusco');
   });
 
-  it('construye payload de parada con defaults', () => {
+  it('construye payload de parada con defaults y campos nuevos', () => {
     const payload = construirParadaPayload(
-      { nombre: 'Lima', coordenadas: [-77.04, -12.04], paisCodigo: 'PE' },
+      { nombre: 'Lima', coordenadas: [-77.04, -12.04], paisCodigo: 'PE', transporte: 'tren', notaCorta: 'Comer ceviche' },
       '2026-02-11',
       { desc: 'Nublado', max: 26, code: 4 }
     );
@@ -95,7 +95,9 @@ describe('viajeUtils', () => {
       fechaSalida: '',
       paisCodigo: 'PE',
       clima: { desc: 'Nublado', max: 26, code: 4 },
-      tipo: 'place'
+      tipo: 'place',
+      transporte: 'tren',
+      notaCorta: 'Comer ceviche'
     });
   });
 
@@ -116,6 +118,20 @@ describe('viajeUtils', () => {
     expect(payload.foto).toBe(FOTO_DEFAULT_URL);
     expect(payload.banderas).toEqual(['https://flagcdn.com/ar.svg']);
     expect(payload.ciudades).toBe('Buenos Aires');
+  });
+
+  it('construye payload de viaje incluyendo presupuesto y vibe', () => {
+    const payload = construirViajePayload({
+      datosViaje: { code: 'AR', nombreEspanol: 'Argentina', presupuesto: 'Lujo', vibe: ['Gastronómico'] },
+      titulo: 'Mi viaje',
+      banderas: ['https://flagcdn.com/ar.svg'],
+      ciudades: 'Buenos Aires',
+      foto: null,
+      fotoCredito: null
+    });
+
+    expect(payload.presupuesto).toBe('Lujo');
+    expect(payload.vibe).toEqual(['Gastronómico']);
   });
 
   it('obtiene paises visitados en ISO3 desde bitacora y paradas', () => {


### PR DESCRIPTION
Resumen

Agrega metadata de storytelling a Viaje ([presupuesto](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [vibe](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [highlights](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) y por‑parada ([transporte](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [notaCorta](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)).
Implementa tagging/companion + flow de invitaciones ([companions](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [invitations](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [sharedWith](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) y reglas de Firestore para acceso compartido.
UI: EdicionModal (chips, autocomplete debounced, invite-by-email), CityManager (transporte + nota), VisorViaje (Trip summary).
Utilities y tests actualizados.
Archivos clave

[viajeSchema.js](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (+ tests)
[firestore.rules](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[invitationsService.js](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[EdicionModal.jsx](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (+ tests)
[CityManager.jsx](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[VisorViaje.jsx](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[viajeUtils.js](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (+ tests)
Checklist (PR)

 Schema y validaciones Zod
 Rules Firestore para [sharedWith](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
 Service de invitations (crear / aceptar)
 EdicionModal: autocomplete debounced, invite-by-email, evitar duplicados
 CityManager: transporte + notaCorta
 Visor: muestra Trip summary (vibe/presupuesto/highlights/companions)
 Tests unitarios para schema, utils y EdicionModal
 Integración: aceptar invitación + [sharedWith](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) subscription (pendiente)
 Fase 3: useScrollyMap (scrollytelling) — pendiente
Cómo probar (QA)

npm run dev
Abrir modal de edición → Contexto del viaje → seleccionar [vibe](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [presupuesto](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) y completar [highlights](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Agregar companion por nombre/email (autocomplete debounced) — verificar [invitations](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) creado (si el viaje está guardado).
Agregar transporte y nota en una parada.
Abrir VisorViaje → verificar Trip summary y que campos nuevos se muestran.
Ejecutar tests: npm test
Riesgos / notas

Reglas Firestore cambiadas: revisar staging antes de prod.
Invitaciones no envían emails (se crea documento [invitations](vscode-file://vscode-app/c:/Users/pinos/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — Cloud Function opcional en futuro).
Campos nuevos son opcionales (backwards‑compatible).